### PR TITLE
fix(syntax): fix theme item not recognize

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antv/infographic",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "An Infographic Generation and Rendering Framework, bring words to life!",
   "keywords": [
     "antv",

--- a/src/syntax/schema.ts
+++ b/src/syntax/schema.ts
@@ -59,6 +59,13 @@ export const ThemeSchema = object(
       shape: shapeStyleSchema,
       text: textStyleSchema,
     }),
+    item: object({
+      icon: object({}, { allowUnknown: true }),
+      label: textStyleSchema,
+      desc: textStyleSchema,
+      value: textStyleSchema,
+      shape: shapeStyleSchema,
+    }),
     stylize: object(
       {
         type: enumOf(['rough', 'pattern']),
@@ -73,6 +80,7 @@ export const ThemeSchema = object(
       },
       { shorthandKey: 'type' },
     ),
+    elements: object({}, { allowUnknown: true }),
   },
   { shorthandKey: 'type' },
 );


### PR DESCRIPTION
- [x] 修复信息图语法中 `theme`.`item`.`xxx` 无法解析的问题

- 关联 Issue: fixed https://github.com/antvis/Infographic/issues/88