### PR TITLE
refactor: fallback icon rendering

### DIFF
--- a/src/renderer/composites/icon.ts
+++ b/src/renderer/composites/icon.ts
@@ -1,28 +1,17 @@
 import { ParsedInfographicOptions } from '../../options';
 import { loadResource, ResourceConfig } from '../../resource';
 import type { DynamicAttributes } from '../../themes';
-import type { IconAttributes, IconElement } from '../../types';
+import type { IconAttributes, ItemDatum } from '../../types';
 import { createIconElement, getAttributes } from '../../utils';
 import { parseDynamicAttributes } from '../utils';
-
-export function renderIcon(
-  svg: SVGSVGElement,
-  node: SVGElement,
-  value: string | ResourceConfig | undefined,
-  attrs: DynamicAttributes<IconAttributes> = {},
-): IconElement | null {
-  if (!value) return null;
-  const parsedAttrs = parseDynamicAttributes(node, attrs);
-
-  return createIcon(svg, node, value, parsedAttrs);
-}
 
 export function renderItemIcon(
   svg: SVGSVGElement,
   node: SVGElement,
-  value: string | ResourceConfig | undefined,
+  datum: ItemDatum,
   options: ParsedInfographicOptions,
 ) {
+  const value = datum.icon;
   if (!value) return null;
   const { themeConfig } = options;
   const attrs: DynamicAttributes<IconAttributes> = {
@@ -30,7 +19,7 @@ export function renderItemIcon(
   };
 
   const parsedAttrs = parseDynamicAttributes(node, attrs);
-  return createIcon(svg, node, value, parsedAttrs);
+  return createIcon(svg, node, value, parsedAttrs, datum);
 }
 
 function createIcon(
@@ -38,9 +27,10 @@ function createIcon(
   node: SVGElement,
   value: string | ResourceConfig,
   attrs: IconAttributes,
+  datum?: ItemDatum,
 ) {
   // load async
-  loadResource(svg, 'icon', value);
+  loadResource(svg, 'icon', value, datum);
 
   return createIconElement(value, {
     ...getAttributes(node, [

--- a/src/renderer/composites/illus.ts
+++ b/src/renderer/composites/illus.ts
@@ -5,7 +5,7 @@ import {
   parseResourceConfig,
   type ResourceConfig,
 } from '../../resource';
-import type { IllusAttributes, IllusElement } from '../../types';
+import type { IllusAttributes, IllusElement, ItemDatum } from '../../types';
 import {
   createElement,
   getAttributes,
@@ -19,6 +19,7 @@ export function renderIllus(
   svg: SVGSVGElement,
   node: SVGElement,
   value: string | ResourceConfig | undefined,
+  datum?: ItemDatum,
 ): IllusElement | null {
   if (!value) return null;
   const config = parseResourceConfig(value);
@@ -27,7 +28,7 @@ export function renderIllus(
   const id = getResourceId(config)!;
   const clipPathId = createClipPath(svg, node, id);
 
-  loadResource(svg, 'illus', config);
+  loadResource(svg, 'illus', config, datum);
 
   const { data, color } = config;
   return createIllusElement(
@@ -39,6 +40,15 @@ export function renderIllus(
     },
     data,
   );
+}
+
+export function renderItemIllus(
+  svg: SVGSVGElement,
+  node: SVGElement,
+  datum: ItemDatum,
+) {
+  const value = datum.illus;
+  return renderIllus(svg, node, value, datum);
 }
 
 function createClipPath(

--- a/src/renderer/composites/index.ts
+++ b/src/renderer/composites/index.ts
@@ -1,8 +1,8 @@
 export { renderBackground } from './background';
 export { renderBaseElement } from './base';
 export { renderButtonsGroup } from './button';
-export { renderIcon, renderItemIcon } from './icon';
-export { renderIllus } from './illus';
+export { renderItemIcon } from './icon';
+export { renderIllus, renderItemIllus } from './illus';
 export { renderShape, renderStaticShape } from './shape';
 export { renderSVG } from './svg';
 export { renderItemText, renderStaticText, renderText } from './text';

--- a/src/renderer/renderer.ts
+++ b/src/renderer/renderer.ts
@@ -25,6 +25,7 @@ import {
   renderButtonsGroup,
   renderIllus,
   renderItemIcon,
+  renderItemIllus,
   renderItemText,
   renderShape,
   renderStaticShape,
@@ -146,6 +147,7 @@ function fill(svg: SVGSVGElement, options: ParsedInfographicOptions) {
     if (element.dataset.elementType?.startsWith('item-')) {
       const indexes = getItemIndexes(element.dataset.indexes || '0');
       const itemType = element.dataset.elementType.replace('item-', '');
+      const datum = getDatumByIndexes(data, indexes);
 
       if (isItemLabel(element) || isItemDesc(element) || isItemValue(element)) {
         const modified = renderItemText(
@@ -155,22 +157,14 @@ function fill(svg: SVGSVGElement, options: ParsedInfographicOptions) {
         );
         return upsert(element, modified);
       }
+      if (!datum) return;
       if (isItemIllus(element)) {
-        const modified = renderIllus(
-          svg,
-          element,
-          getDatumByIndexes(data, indexes)?.illus,
-        );
+        const modified = renderItemIllus(svg, element, datum);
         return upsert(element, modified);
       }
 
       if (isItemIcon(element)) {
-        const modified = renderItemIcon(
-          svg,
-          element,
-          getDatumByIndexes(data, indexes)?.icon,
-          options,
-        );
+        const modified = renderItemIcon(svg, element, datum, options);
         return upsert(element, modified);
       }
     }


### PR DESCRIPTION
This change improves the resource loading fallback: when the primary loader fails, it always falls back to loadSearchResource, preferring `datum.label / datum.desc` as the query to better match the item context. If no `datum` is available, it falls back to the configured data (excluding `inline/data-uri/svg`), and finally to a default `icon/illustration`, so we avoid returning null for missing resources.

---

本次调整优化了资源加载的兜底逻辑：当主加载路径失败时，统一回退到 `loadSearchResource`，并优先使用 `datum.label / datum.desc` 作为 query（更贴近语义场景）。若 `datum` 不可用，则退回到配置中的 `data`（排除 `inline/data-uri/svg`），最后使用默认的 `icon/illustration`，确保不会因加载失败返回空资源。