### PR TITLE
fix(site): disable remove trailing slash

### DIFF
--- a/site/next.config.js
+++ b/site/next.config.js
@@ -5,7 +5,6 @@ const nextConfig = {
   pageExtensions: ['jsx', 'js', 'ts', 'tsx', 'mdx', 'md'],
   reactStrictMode: true,
   output: 'export',
-  trailingSlash: true,
   images: {
     // Static export needs unoptimized images
     unoptimized: true,


### PR DESCRIPTION
- [x] Disable remove trailing slash to avoid category can not be expanded.