### PR TITLE
fix: infographic text overlap

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -410,7 +410,7 @@ AntVInfographic.registerResourceLoader(async (config) => {
   infographic.render(`{syntax}`);
   document.fonts?.ready.then(() => {
     infographic.render(`{syntax}`);
-  }).catch(() => {});
+  }).catch((error) => console.error('Error waiting for fonts to load:', error));
 </script>
 ```
 


### PR DESCRIPTION
I saw the title and description overlap on first render. Root cause: text boxes are measured before fonts finish loading; if measurement and final render use different fonts (or fonts load after mount), sizes are wrong. The skill should generate HTML that renders reliably across browsers/system fonts without overlaps.

Examples before the fix:
<img width="732" height="512" alt="CleanShot 2025-12-31 at 22 22 38@2x" src="https://github.com/user-attachments/assets/ac6b0e09-f73e-4b33-8581-1491293fb81a" />

after the fix:
<img width="658" height="490" alt="CleanShot 2025-12-31 at 22 23 06@2x" src="https://github.com/user-attachments/assets/da27fff5-cfc2-4ed3-a472-12eed2489f6e" />
