### PR TITLE
feat: 新增瀑布流模板 list-waterfall-badge-card / list-waterfall-compact-card

### DIFF
--- a/.skills/infographic-creator/SKILL.md
+++ b/.skills/infographic-creator/SKILL.md
@@ -228,6 +228,8 @@ data
 - list-grid-ribbon-card
 - list-row-horizontal-icon-arrow
 - list-sector-plain-text
+- list-waterfall-badge-card
+- list-waterfall-compact-card
 - list-zigzag-down-compact-card
 - list-zigzag-down-simple
 - list-zigzag-up-compact-card

--- a/.skills/infographic-syntax-creator/references/prompt.md
+++ b/.skills/infographic-syntax-creator/references/prompt.md
@@ -242,6 +242,8 @@ data
 - list-grid-ribbon-card
 - list-row-horizontal-icon-arrow
 - list-sector-plain-text
+- list-waterfall-badge-card
+- list-waterfall-compact-card
 - list-zigzag-down-compact-card
 - list-zigzag-down-simple
 - list-zigzag-up-compact-card

--- a/src/templates/built-in.ts
+++ b/src/templates/built-in.ts
@@ -351,6 +351,20 @@ const BUILT_IN_TEMPLATES: Record<string, TemplateOptions> = {
       items: [{ type: 'plain-text' }],
     },
   },
+  'list-waterfall-badge-card': {
+    design: {
+      title: 'default',
+      structure: { type: 'list-waterfall' },
+      items: [{ type: 'badge-card' }],
+    },
+  },
+  'list-waterfall-compact-card': {
+    design: {
+      title: 'default',
+      structure: { type: 'list-waterfall' },
+      items: [{ type: 'compact-card' }],
+    },
+  },
   'sequence-roadmap-vertical-plain-text': {
     design: {
       title: 'default',


### PR DESCRIPTION
## 变更说明

- 新增内置模板：`list-waterfall-badge-card`、`list-waterfall-compact-card`，基于已有结构 `list-waterfall` 提供瀑布流布局的两种卡片样式。
- 更新模板列表：`.skills/infographic-creator/SKILL.md`、`.skills/infographic-syntax-creator/references/prompt.md` 中的可用模板列表。

## 使用方式

数据格式与现有 list 类模板一致，支持 `lists` 或兜底 `items`：

infographic list-waterfall-badge-card
```
data
  title My Gallery
  lists
    - label Item 1
      icon star
    - label Item 2
      icon heart
```
