### PR TITLE
feat: add relation-network templates: relation-network-simple-circle-…

### DIFF
--- a/.skills/infographic-syntax-creator/references/prompt.md
+++ b/.skills/infographic-syntax-creator/references/prompt.md
@@ -252,8 +252,6 @@ data
 - relation-dagre-flow-tb-animated-simple-circle-node
 - relation-dagre-flow-tb-badge-card
 - relation-dagre-flow-tb-simple-circle-node
-- relation-network-icon-badge
-- relation-network-simple-circle-node
 - sequence-ascending-stairs-3d-underline-text
 - sequence-ascending-steps
 - sequence-circular-simple


### PR DESCRIPTION
## 变更说明

- 新增内置模板：`relation-network-simple-circle-node`、`relation-network-icon-badge`，基于已有结构 `relation-network`（力导向布局）提供两种节点样式。
- 更新模板列表：`.skills/infographic-creator/SKILL.md`、`.skills/infographic-syntax-creator/references/prompt.md` 中的可用模板列表。

## 使用方式

数据格式与现有 relation 类模板一致，支持 `nodes` + `relations` 或兜底 `items`（中心-多节点由力导向自动布线）：
```
infographic relation-network-simple-circle-node
data
  title 概念关系网络
  nodes
    - id center
      label 核心概念
    - id a
      label 概念 A
  relations
    center -> a
```
如下图示：
<img width="1486" height="850" alt="截屏2026-02-05 09 01 13" src="https://github.com/user-attachments/assets/1ce95484-385b-43a7-a1e5-c9dd2e4f1f7f" />
<img width="1480" height="856" alt="截屏2026-02-05 09 00 55" src="https://github.com/user-attachments/assets/dbafc9f4-8ab0-40f3-a49b-28d905eb5482" />
<img width="1491" height="856" alt="截屏2026-02-05 09 00 40" src="https://github.com/user-attachments/assets/b15e4bfc-dca6-4729-8378-5e8c89e1321d" />
