### PR TITLE
refactor(editor): streamline option updates and simplify change bubbling mechanism

### DIFF
--- a/__tests__/unit/editor/utils/object.test.ts
+++ b/__tests__/unit/editor/utils/object.test.ts
@@ -197,6 +197,21 @@ describe('applyOptionUpdates', () => {
     expect(target).toEqual({});
   });
 
+  it('detects change when primitive is replaced by empty object', () => {
+    const target = { a: 1 };
+    const source = { a: {} };
+    const collector = vi.fn();
+    applyOptionUpdates(target, source, '', { bubbleUp: true, collector });
+
+    expect(target.a).toEqual({});
+    // Even if 'a' itself doesn't fire as a leaf, the root MUST change because 'a' changed.
+    expect(collector).toHaveBeenCalledWith(
+      '',
+      expect.objectContaining({ a: {} }),
+      undefined,
+    );
+  });
+
   it('collects cloned values during bubble up to prevent side effects', () => {
     const target = { a: { b: 1 } };
     const source = { a: { b: 2 } };


### PR DESCRIPTION
## 📝 背景 (Background)

在现有的配置项更新逻辑中，为了实现 **变更冒泡（Bubble Up）** 并确保通知顺序，系统采用了显式集合（`Set`）记录变更路径，并在处理结束后进行深度排序与二次遍历。

**存在的问题：**

* **复杂度高：** 路径解析与深拷贝逻辑带来了额外的计算开销。
* **流程冗余：** 显式的集合维护与排序步骤增加了代码的维护成本。

**优化目标：**
利用递归天然的执行顺序优化逻辑流转，在**降低代码复杂度**的同时，显著提升**整体执行效率**。

---

## ✨ 主要改动 (Changes)

### 1. 逻辑链路简化

* **递归回溯：** 通过让递归函数 `applyOptionUpdatesInternal` 返回变更状态（`boolean`），将原本离散的父路径收集过程转化为函数调用栈的**自然回溯**。
* **状态透传：** 移除了中间状态的存储介质，使逻辑更加纯粹。

### 2. 自然的执行序管理

* **后序遍历应用：** 利用递归“由深及浅”的特性，天然实现了冒泡通知。
* **时序保证：** 确保在通知父级更新时，子级状态已处理完成，无需再进行额外的显式排序。

### 3. 性能与依赖优化

* **去依赖化：** 移除了 `lodash-es` 的 `cloneDeep` 与 `get` 调用，大幅减少了内存占用与路径解析开销。
* **轻量化处理：** 精简了路径字符串的拆解操作，提升了更新过程的执行速度。

