### PR TITLE
fix(exporter): 修复 PNG 导出多行文本截断与宽度异常问题

### DIFF
--- a/__tests__/unit/exporter/svg.test.ts
+++ b/__tests__/unit/exporter/svg.test.ts
@@ -371,4 +371,127 @@ describe('exporter/svg', () => {
     expect(exported.getAttribute('width')).toBe('320');
     expect(exported.getAttribute('height')).toBe('270');
   });
+
+  it('keeps wrapped foreignObject text within the original export width', async () => {
+    const svg = document.createElementNS(svgNS, 'svg');
+    svg.setAttribute('viewBox', '0 0 200 100');
+    mockSvgCoordinateSpace(svg);
+
+    const foreignObject = document.createElementNS(svgNS, 'foreignObject');
+    const span = document.createElement('span');
+    span.style.width = '100%';
+    span.style.height = '100%';
+    span.style.display = 'flex';
+    span.style.flexWrap = 'wrap';
+    span.style.wordBreak = 'break-word';
+    span.style.whiteSpace = 'pre-wrap';
+
+    Object.defineProperty(span, 'scrollWidth', {
+      configurable: true,
+      get: () => 320,
+    });
+    Object.defineProperty(span, 'scrollHeight', {
+      configurable: true,
+      get: () => 160,
+    });
+
+    foreignObject.appendChild(span);
+    svg.appendChild(foreignObject);
+
+    mockRect(foreignObject, { left: 0, top: 0, width: 200, height: 100 });
+
+    const exported = await exportToSVG(svg);
+
+    expect(exported.getAttribute('viewBox')).toBe('0 0 200 160');
+    expect(exported.getAttribute('width')).toBe('200');
+    expect(exported.getAttribute('height')).toBe('160');
+  });
+
+  it('resizes exported foreignObject height to the measured wrapped content height', async () => {
+    const svg = document.createElementNS(svgNS, 'svg');
+    svg.setAttribute('viewBox', '0 0 200 100');
+    mockSvgCoordinateSpace(svg);
+
+    const foreignObject = document.createElementNS(svgNS, 'foreignObject');
+    foreignObject.setAttribute('x', '20');
+    foreignObject.setAttribute('y', '30');
+    foreignObject.setAttribute('width', '140');
+    foreignObject.setAttribute('height', '40');
+
+    const span = document.createElement('span');
+    span.style.width = '100%';
+    span.style.height = '100%';
+    span.style.display = 'flex';
+    span.style.flexWrap = 'wrap';
+    span.style.wordBreak = 'break-word';
+    span.style.whiteSpace = 'pre-wrap';
+
+    Object.defineProperty(span, 'scrollHeight', {
+      configurable: true,
+      get: () => 80,
+    });
+
+    foreignObject.appendChild(span);
+    svg.appendChild(foreignObject);
+
+    mockRect(foreignObject, { left: 20, top: 30, width: 140, height: 40 });
+
+    const exported = await exportToSVG(svg);
+    const exportedForeignObject = exported.querySelector('foreignObject');
+
+    expect(exportedForeignObject?.getAttribute('x')).toBe('20');
+    expect(exportedForeignObject?.getAttribute('y')).toBe('30');
+    expect(exportedForeignObject?.getAttribute('width')).toBe('140');
+    expect(exportedForeignObject?.getAttribute('height')).toBe('80');
+  });
+
+  it('uses rendered content height when it is larger than scrollHeight', async () => {
+    const svg = document.createElementNS(svgNS, 'svg');
+    svg.setAttribute('viewBox', '0 0 200 100');
+    mockSvgCoordinateSpace(svg);
+
+    const foreignObject = document.createElementNS(svgNS, 'foreignObject');
+    foreignObject.setAttribute('x', '20');
+    foreignObject.setAttribute('y', '30');
+    foreignObject.setAttribute('width', '140');
+    foreignObject.setAttribute('height', '40');
+
+    const span = document.createElement('span');
+    span.style.width = '100%';
+    span.style.height = '100%';
+    span.style.display = 'flex';
+    span.style.flexWrap = 'wrap';
+    span.style.wordBreak = 'break-word';
+    span.style.whiteSpace = 'pre-wrap';
+
+    Object.defineProperty(span, 'scrollHeight', {
+      configurable: true,
+      get: () => 80,
+    });
+    Object.defineProperty(span, 'getBoundingClientRect', {
+      configurable: true,
+      value: () =>
+        ({
+          x: 0,
+          y: 0,
+          left: 0,
+          top: 0,
+          width: 140,
+          height: 84.4,
+          right: 140,
+          bottom: 84.4,
+          toJSON: () => ({}),
+        }) as DOMRect,
+    });
+
+    foreignObject.appendChild(span);
+    svg.appendChild(foreignObject);
+
+    mockRect(foreignObject, { left: 20, top: 30, width: 140, height: 40 });
+
+    const exported = await exportToSVG(svg);
+    const exportedForeignObject = exported.querySelector('foreignObject');
+
+    expect(exportedForeignObject?.getAttribute('height')).toBe('84.4');
+  });
 });

--- a/__tests__/unit/exporter/svg.test.ts
+++ b/__tests__/unit/exporter/svg.test.ts
@@ -87,6 +87,47 @@ function mockSvgCoordinateSpace(
   });
 }
 
+function mockElementCoordinateSpace(
+  svg: SVGSVGElement,
+  element: SVGGraphicsElement,
+  {
+    scaleX = 1,
+    scaleY = 1,
+    translateX = 0,
+    translateY = 0,
+  }: {
+    scaleX?: number;
+    scaleY?: number;
+    translateX?: number;
+    translateY?: number;
+  } = {},
+) {
+  const screenCTM = {
+    a: scaleX,
+    d: scaleY,
+    e: translateX,
+    f: translateY,
+    inverse() {
+      return {
+        a: 1 / scaleX,
+        d: 1 / scaleY,
+        e: -translateX / scaleX,
+        f: -translateY / scaleY,
+      };
+    },
+  };
+
+  Object.defineProperty(element, 'getScreenCTM', {
+    configurable: true,
+    value: () => screenCTM,
+  });
+
+  Object.defineProperty(element, 'createSVGPoint', {
+    configurable: true,
+    value: () => svg.createSVGPoint(),
+  });
+}
+
 describe('exporter/svg', () => {
   beforeEach(() => {
     document.body.innerHTML = '';
@@ -550,5 +591,51 @@ describe('exporter/svg', () => {
     expect(secondForeignObject?.getAttribute('y')).toBe('30');
     expect(secondForeignObject?.getAttribute('width')).toBe('140');
     expect(secondForeignObject?.getAttribute('height')).toBe('80');
+  });
+
+  it('does not double-apply foreignObject transforms when resizing exported bounds', async () => {
+    const svg = document.createElementNS(svgNS, 'svg');
+    svg.setAttribute('viewBox', '0 0 200 100');
+    mockSvgCoordinateSpace(svg);
+
+    const foreignObject = document.createElementNS(svgNS, 'foreignObject');
+    foreignObject.setAttribute('x', '20');
+    foreignObject.setAttribute('y', '30');
+    foreignObject.setAttribute('width', '140');
+    foreignObject.setAttribute('height', '40');
+    foreignObject.setAttribute('transform', 'translate(5 7)');
+
+    const span = document.createElement('span');
+    span.style.width = '100%';
+    span.style.height = '100%';
+    span.style.display = 'flex';
+    span.style.flexWrap = 'wrap';
+    span.style.wordBreak = 'break-word';
+    span.style.whiteSpace = 'pre-wrap';
+
+    Object.defineProperty(span, 'scrollHeight', {
+      configurable: true,
+      get: () => 80,
+    });
+
+    foreignObject.appendChild(span);
+    svg.appendChild(foreignObject);
+
+    mockRect(foreignObject, { left: 25, top: 37, width: 140, height: 40 });
+    mockElementCoordinateSpace(svg, foreignObject as SVGGraphicsElement, {
+      translateX: 25,
+      translateY: 37,
+    });
+
+    const exported = await exportToSVG(svg);
+    const exportedForeignObject = exported.querySelector('foreignObject');
+
+    expect(exportedForeignObject?.getAttribute('x')).toBe('20');
+    expect(exportedForeignObject?.getAttribute('y')).toBe('30');
+    expect(exportedForeignObject?.getAttribute('width')).toBe('140');
+    expect(exportedForeignObject?.getAttribute('height')).toBe('80');
+    expect(exportedForeignObject?.getAttribute('transform')).toBe(
+      'translate(5 7)',
+    );
   });
 });

--- a/__tests__/unit/exporter/svg.test.ts
+++ b/__tests__/unit/exporter/svg.test.ts
@@ -494,4 +494,61 @@ describe('exporter/svg', () => {
 
     expect(exportedForeignObject?.getAttribute('height')).toBe('84.4');
   });
+
+  it('keeps foreignObject adjustments aligned when earlier foreignObjects are skipped', async () => {
+    const svg = document.createElementNS(svgNS, 'svg');
+    svg.setAttribute('viewBox', '0 0 200 100');
+    mockSvgCoordinateSpace(svg);
+
+    const skippedForeignObject = document.createElementNS(svgNS, 'foreignObject');
+    skippedForeignObject.setAttribute('x', '0');
+    skippedForeignObject.setAttribute('y', '0');
+    skippedForeignObject.setAttribute('width', '10');
+    skippedForeignObject.setAttribute('height', '10');
+    svg.appendChild(skippedForeignObject);
+
+    const adjustedForeignObject = document.createElementNS(
+      svgNS,
+      'foreignObject',
+    );
+    adjustedForeignObject.setAttribute('x', '20');
+    adjustedForeignObject.setAttribute('y', '30');
+    adjustedForeignObject.setAttribute('width', '140');
+    adjustedForeignObject.setAttribute('height', '40');
+
+    const span = document.createElement('span');
+    span.style.width = '100%';
+    span.style.height = '100%';
+    span.style.display = 'flex';
+    span.style.flexWrap = 'wrap';
+    span.style.wordBreak = 'break-word';
+    span.style.whiteSpace = 'pre-wrap';
+
+    Object.defineProperty(span, 'scrollHeight', {
+      configurable: true,
+      get: () => 80,
+    });
+
+    adjustedForeignObject.appendChild(span);
+    svg.appendChild(adjustedForeignObject);
+
+    mockRect(skippedForeignObject, { left: 0, top: 0, width: 10, height: 10 });
+    mockRect(adjustedForeignObject, {
+      left: 20,
+      top: 30,
+      width: 140,
+      height: 40,
+    });
+
+    const exported = await exportToSVG(svg);
+    const [firstForeignObject, secondForeignObject] =
+      exported.querySelectorAll('foreignObject');
+
+    expect(firstForeignObject?.getAttribute('width')).toBe('10');
+    expect(firstForeignObject?.getAttribute('height')).toBe('10');
+    expect(secondForeignObject?.getAttribute('x')).toBe('20');
+    expect(secondForeignObject?.getAttribute('y')).toBe('30');
+    expect(secondForeignObject?.getAttribute('width')).toBe('140');
+    expect(secondForeignObject?.getAttribute('height')).toBe('80');
+  });
 });

--- a/src/exporter/svg.ts
+++ b/src/exporter/svg.ts
@@ -91,12 +91,15 @@ function shouldKeepForeignObjectWidth(style: CSSStyleDeclaration): boolean {
   const whiteSpace = style.whiteSpace;
   const flexWrap = style.flexWrap;
   const wordBreak = style.wordBreak;
+  const overflowWrap = style.overflowWrap;
 
   return (
     flexWrap === 'wrap' ||
     flexWrap === 'wrap-reverse' ||
     whiteSpace === 'pre-wrap' ||
+    whiteSpace === 'pre-line' ||
     whiteSpace === 'normal' ||
+    overflowWrap === 'break-word' ||
     wordBreak === 'break-word' ||
     wordBreak === 'break-all'
   );
@@ -203,27 +206,25 @@ function collectForeignObjectExportAdjustments(svg: SVGSVGElement) {
 
   return Array.from(
     svg.querySelectorAll<SVGForeignObjectElement>('foreignObject'),
-  ).flatMap((fo) => {
+  ).map((fo) => {
     const content = fo.firstElementChild as HTMLElement | null;
-    if (!content) return [];
+    if (!content) return null;
 
     const parent =
       fo.parentElement instanceof SVGGraphicsElement ? fo.parentElement : svg;
     const toParentCoord = createCoordConverter(svg, parent);
-    if (!toParentCoord) return [];
+    if (!toParentCoord) return null;
 
-    return [
-      {
-        rootBounds: getFOContentBoundsInSVG(fo, content, toSVGCoord),
-        localBounds: getFOContentBoundsInSVG(fo, content, toParentCoord),
-      } satisfies ForeignObjectExportAdjustment,
-    ];
+    return {
+      rootBounds: getFOContentBoundsInSVG(fo, content, toSVGCoord),
+      localBounds: getFOContentBoundsInSVG(fo, content, toParentCoord),
+    } satisfies ForeignObjectExportAdjustment;
   });
 }
 
 function computeFullViewBox(
   svg: SVGSVGElement,
-  adjustments: ForeignObjectExportAdjustment[],
+  adjustments: Array<ForeignObjectExportAdjustment | null>,
 ): string | null {
   const viewBox = getExportViewBox(svg);
   if (!viewBox) return null;
@@ -233,7 +234,9 @@ function computeFullViewBox(
   let maxX = viewBox.x + viewBox.width;
   let maxY = viewBox.y + viewBox.height;
 
-  adjustments.forEach(({ rootBounds }) => {
+  adjustments.forEach((adjustment) => {
+    if (!adjustment) return;
+    const { rootBounds } = adjustment;
     const [left, top, right, bottom] = rootBounds;
     minX = Math.min(minX, left);
     minY = Math.min(minY, top);
@@ -258,13 +261,14 @@ function computeFullViewBox(
 
 function applyForeignObjectExportAdjustments(
   svg: SVGSVGElement,
-  adjustments: ForeignObjectExportAdjustment[],
+  adjustments: Array<ForeignObjectExportAdjustment | null>,
 ) {
   const clonedForeignObjects = Array.from(
     svg.querySelectorAll<SVGForeignObjectElement>('foreignObject'),
   );
 
   adjustments.forEach((adjustment, index) => {
+    if (!adjustment) return;
     const clonedForeignObject = clonedForeignObjects[index];
     if (!clonedForeignObject) return;
 

--- a/src/exporter/svg.ts
+++ b/src/exporter/svg.ts
@@ -11,6 +11,12 @@ import { embedFonts } from './font';
 import type { SVGExportOptions } from './types';
 
 const VIEWBOX_CHANGE_TOLERANCE = 0.5;
+type BoundsTuple = [number, number, number, number];
+
+interface ForeignObjectExportAdjustment {
+  rootBounds: BoundsTuple;
+  localBounds: BoundsTuple;
+}
 
 export async function exportToSVGString(
   svg: SVGSVGElement,
@@ -58,7 +64,9 @@ function measureSpanContentHeight(span: HTMLElement): number {
     span.style.height = 'max-content';
     span.style.overflow = 'hidden';
     void span.offsetHeight; // force reflow
-    return span.scrollHeight;
+    const scrollHeight = span.scrollHeight;
+    const rectHeight = span.getBoundingClientRect().height;
+    return Math.max(scrollHeight, rectHeight);
   } finally {
     span.style.height = prevHeight;
     span.style.overflow = prevOverflow;
@@ -79,7 +87,39 @@ function measureSpanContentWidth(span: HTMLElement): number {
   }
 }
 
-// Returns [left, top, right, bottom] in SVG coordinates for a foreignObject,
+function shouldKeepForeignObjectWidth(style: CSSStyleDeclaration): boolean {
+  const whiteSpace = style.whiteSpace;
+  const flexWrap = style.flexWrap;
+  const wordBreak = style.wordBreak;
+
+  return (
+    flexWrap === 'wrap' ||
+    flexWrap === 'wrap-reverse' ||
+    whiteSpace === 'pre-wrap' ||
+    whiteSpace === 'normal' ||
+    wordBreak === 'break-word' ||
+    wordBreak === 'break-all'
+  );
+}
+
+function createCoordConverter(
+  svg: SVGSVGElement,
+  element: SVGGraphicsElement,
+): ((x: number, y: number) => SVGPoint) | null {
+  if (typeof element.getScreenCTM !== 'function') return null;
+  const screenCTM = element.getScreenCTM();
+  if (!screenCTM) return null;
+  const inverseCTM = screenCTM.inverse();
+
+  return (clientX: number, clientY: number) => {
+    const pt = svg.createSVGPoint();
+    pt.x = clientX;
+    pt.y = clientY;
+    return pt.matrixTransform(inverseCTM);
+  };
+}
+
+// Returns [left, top, right, bottom] in target coordinates for a foreignObject,
 // accounting for flex alignment: bottom/center-aligned content can overflow,
 // and horizontally aligned content can overflow as well.
 function getFOContentBoundsInSVG(
@@ -110,13 +150,17 @@ function getFOContentBoundsInSVG(
       ? realScrollHeight * svgUnitsPerClientPxY
       : foHeightSVG;
 
-  const realScrollWidth = measureSpanContentWidth(content);
-  const contentWidthSVG =
-    realScrollWidth > 0 ? realScrollWidth * svgUnitsPerClientPxX : foWidthSVG;
-
   const computedStyle = window.getComputedStyle(content);
   const alignItems = computedStyle.alignItems;
   const justifyContent = computedStyle.justifyContent;
+  const contentWidthSVG = shouldKeepForeignObjectWidth(computedStyle)
+    ? foWidthSVG
+    : (() => {
+        const realScrollWidth = measureSpanContentWidth(content);
+        return realScrollWidth > 0
+          ? Math.max(foWidthSVG, realScrollWidth * svgUnitsPerClientPxX)
+          : foWidthSVG;
+      })();
 
   // Calculate vertical bounds
   let top: number, bottom: number;
@@ -153,47 +197,49 @@ function getFOContentBoundsInSVG(
   return [left, top, right, bottom];
 }
 
-/**
- * Computes a viewBox that fully covers all foreignObject text content,
- * accounting for overflow caused by flex alignment (bottom/center align
- * can push content outside the foreignObject bounds).
- */
-function computeFullViewBox(svg: SVGSVGElement): string | null {
+function collectForeignObjectExportAdjustments(svg: SVGSVGElement) {
+  const toSVGCoord = createCoordConverter(svg, svg);
+  if (!toSVGCoord) return [];
+
+  return Array.from(
+    svg.querySelectorAll<SVGForeignObjectElement>('foreignObject'),
+  ).flatMap((fo) => {
+    const content = fo.firstElementChild as HTMLElement | null;
+    if (!content) return [];
+
+    const parent =
+      fo.parentElement instanceof SVGGraphicsElement ? fo.parentElement : svg;
+    const toParentCoord = createCoordConverter(svg, parent);
+    if (!toParentCoord) return [];
+
+    return [
+      {
+        rootBounds: getFOContentBoundsInSVG(fo, content, toSVGCoord),
+        localBounds: getFOContentBoundsInSVG(fo, content, toParentCoord),
+      } satisfies ForeignObjectExportAdjustment,
+    ];
+  });
+}
+
+function computeFullViewBox(
+  svg: SVGSVGElement,
+  adjustments: ForeignObjectExportAdjustment[],
+): string | null {
   const viewBox = getExportViewBox(svg);
   if (!viewBox) return null;
-
-  if (typeof svg.getScreenCTM !== 'function') return null;
-  const screenCTM = svg.getScreenCTM();
-  if (!screenCTM) return null;
-  const inverseCTM = screenCTM.inverse();
-
-  const toSVGCoord = (clientX: number, clientY: number) => {
-    const pt = svg.createSVGPoint();
-    pt.x = clientX;
-    pt.y = clientY;
-    return pt.matrixTransform(inverseCTM);
-  };
 
   let minX = viewBox.x;
   let minY = viewBox.y;
   let maxX = viewBox.x + viewBox.width;
   let maxY = viewBox.y + viewBox.height;
 
-  svg
-    .querySelectorAll<SVGForeignObjectElement>('foreignObject')
-    .forEach((fo) => {
-      const content = fo.firstElementChild as HTMLElement;
-      if (!content) return;
-      const [left, top, right, bottom] = getFOContentBoundsInSVG(
-        fo,
-        content,
-        toSVGCoord,
-      );
-      minX = Math.min(minX, left);
-      minY = Math.min(minY, top);
-      maxX = Math.max(maxX, right);
-      maxY = Math.max(maxY, bottom);
-    });
+  adjustments.forEach(({ rootBounds }) => {
+    const [left, top, right, bottom] = rootBounds;
+    minX = Math.min(minX, left);
+    minY = Math.min(minY, top);
+    maxX = Math.max(maxX, right);
+    maxY = Math.max(maxY, bottom);
+  });
 
   const newX = minX;
   const newY = minY;
@@ -210,6 +256,28 @@ function computeFullViewBox(svg: SVGSVGElement): string | null {
   return `${newX} ${newY} ${newWidth} ${newHeight}`;
 }
 
+function applyForeignObjectExportAdjustments(
+  svg: SVGSVGElement,
+  adjustments: ForeignObjectExportAdjustment[],
+) {
+  const clonedForeignObjects = Array.from(
+    svg.querySelectorAll<SVGForeignObjectElement>('foreignObject'),
+  );
+
+  adjustments.forEach((adjustment, index) => {
+    const clonedForeignObject = clonedForeignObjects[index];
+    if (!clonedForeignObject) return;
+
+    const [left, top, right, bottom] = adjustment.localBounds;
+    setAttributes(clonedForeignObject, {
+      x: left,
+      y: top,
+      width: right - left,
+      height: bottom - top,
+    });
+  });
+}
+
 export async function exportToSVG(
   svg: SVGSVGElement,
   options: Omit<SVGExportOptions, 'type'> = {},
@@ -222,7 +290,9 @@ export async function exportToSVG(
   const clonedSVG = svg.cloneNode(true) as SVGSVGElement;
 
   if (typeof document !== 'undefined') {
-    const fullViewBox = computeFullViewBox(svg);
+    const adjustments = collectForeignObjectExportAdjustments(svg);
+    applyForeignObjectExportAdjustments(clonedSVG, adjustments);
+    const fullViewBox = computeFullViewBox(svg, adjustments);
     if (fullViewBox) {
       clonedSVG.setAttribute('viewBox', fullViewBox);
     }

--- a/src/exporter/svg.ts
+++ b/src/exporter/svg.ts
@@ -15,7 +15,12 @@ type BoundsTuple = [number, number, number, number];
 
 interface ForeignObjectExportAdjustment {
   rootBounds: BoundsTuple;
-  localBounds: BoundsTuple;
+  exportBounds: {
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+  };
 }
 
 export async function exportToSVGString(
@@ -55,6 +60,11 @@ function parseAbsoluteLength(value: string | null): number {
   if (!trimmed) return Number.NaN;
   if (!/^[-+]?(?:\d+\.?\d*|\.\d+)(?:px)?$/.test(trimmed)) return Number.NaN;
   return Number.parseFloat(trimmed);
+}
+
+function parseCoordinate(value: string | null): number {
+  const parsed = parseAbsoluteLength(value);
+  return Number.isNaN(parsed) ? 0 : parsed;
 }
 
 function measureSpanContentHeight(span: HTMLElement): number {
@@ -158,12 +168,7 @@ function getFOContentBoundsInSVG(
   const justifyContent = computedStyle.justifyContent;
   const contentWidthSVG = shouldKeepForeignObjectWidth(computedStyle)
     ? foWidthSVG
-    : (() => {
-        const realScrollWidth = measureSpanContentWidth(content);
-        return realScrollWidth > 0
-          ? Math.max(foWidthSVG, realScrollWidth * svgUnitsPerClientPxX)
-          : foWidthSVG;
-      })();
+    : Math.max(foWidthSVG, measureSpanContentWidth(content) * svgUnitsPerClientPxX);
 
   // Calculate vertical bounds
   let top: number, bottom: number;
@@ -213,11 +218,35 @@ function collectForeignObjectExportAdjustments(svg: SVGSVGElement) {
     const parent =
       fo.parentElement instanceof SVGGraphicsElement ? fo.parentElement : svg;
     const toParentCoord = createCoordConverter(svg, parent);
+    const toLocalCoord = createCoordConverter(svg, fo);
     if (!toParentCoord) return null;
+
+    const parentBounds = getFOContentBoundsInSVG(fo, content, toParentCoord);
+    const originalX = parseCoordinate(fo.getAttribute('x'));
+    const originalY = parseCoordinate(fo.getAttribute('y'));
+    const localBounds = toLocalCoord
+      ? getFOContentBoundsInSVG(fo, content, toLocalCoord)
+      : null;
+    const hasTransform = fo.hasAttribute('transform');
+    if (hasTransform && !localBounds) return null;
+
+    const exportBounds = localBounds
+      ? {
+          x: originalX + localBounds[0],
+          y: originalY + localBounds[1],
+          width: localBounds[2] - localBounds[0],
+          height: localBounds[3] - localBounds[1],
+        }
+      : {
+          x: parentBounds[0],
+          y: parentBounds[1],
+          width: parentBounds[2] - parentBounds[0],
+          height: parentBounds[3] - parentBounds[1],
+        };
 
     return {
       rootBounds: getFOContentBoundsInSVG(fo, content, toSVGCoord),
-      localBounds: getFOContentBoundsInSVG(fo, content, toParentCoord),
+      exportBounds,
     } satisfies ForeignObjectExportAdjustment;
   });
 }
@@ -272,13 +301,7 @@ function applyForeignObjectExportAdjustments(
     const clonedForeignObject = clonedForeignObjects[index];
     if (!clonedForeignObject) return;
 
-    const [left, top, right, bottom] = adjustment.localBounds;
-    setAttributes(clonedForeignObject, {
-      x: left,
-      y: top,
-      width: right - left,
-      height: bottom - top,
-    });
+    setAttributes(clonedForeignObject, adjustment.exportBounds);
   });
 }
 

--- a/src/exporter/svg.ts
+++ b/src/exporter/svg.ts
@@ -67,8 +67,17 @@ function parseCoordinate(value: string | null): number {
   return Number.isNaN(parsed) ? 0 : parsed;
 }
 
-function measureSpanContentHeight(span: HTMLElement): number {
+interface MeasuredSpanContentDimensions {
+  height: number;
+  width: number;
+}
+
+function measureSpanContentDimensions(
+  span: HTMLElement,
+  measureWidth: boolean,
+): MeasuredSpanContentDimensions {
   const prevHeight = span.style.height;
+  const prevWidth = span.style.width;
   const prevOverflow = span.style.overflow;
   try {
     span.style.height = 'max-content';
@@ -76,22 +85,20 @@ function measureSpanContentHeight(span: HTMLElement): number {
     void span.offsetHeight; // force reflow
     const scrollHeight = span.scrollHeight;
     const rectHeight = span.getBoundingClientRect().height;
-    return Math.max(scrollHeight, rectHeight);
+    let width = span.scrollWidth;
+
+    if (measureWidth) {
+      span.style.width = 'max-content';
+      void span.offsetWidth; // force reflow
+      width = span.scrollWidth;
+    }
+
+    return {
+      height: Math.max(scrollHeight, rectHeight),
+      width,
+    };
   } finally {
     span.style.height = prevHeight;
-    span.style.overflow = prevOverflow;
-  }
-}
-
-function measureSpanContentWidth(span: HTMLElement): number {
-  const prevWidth = span.style.width;
-  const prevOverflow = span.style.overflow;
-  try {
-    span.style.width = 'max-content';
-    span.style.overflow = 'hidden';
-    void span.offsetWidth; // force reflow
-    return span.scrollWidth;
-  } finally {
     span.style.width = prevWidth;
     span.style.overflow = prevOverflow;
   }
@@ -137,8 +144,16 @@ function createCoordConverter(
 // and horizontally aligned content can overflow as well.
 function getFOContentBoundsInSVG(
   fo: SVGForeignObjectElement,
-  content: HTMLElement,
   toSVGCoord: (x: number, y: number) => SVGPoint,
+  {
+    contentHeight,
+    contentWidth,
+    keepForeignObjectWidth,
+  }: {
+    contentHeight: number;
+    contentWidth: number;
+    keepForeignObjectWidth: boolean;
+  },
 ): [number, number, number, number] {
   const foRect = fo.getBoundingClientRect();
   const foTopLeft = toSVGCoord(foRect.left, foRect.top);
@@ -156,19 +171,17 @@ function getFOContentBoundsInSVG(
     foRect.height > 0 ? foHeightSVG / foRect.height : 1;
   const svgUnitsPerClientPxX = foRect.width > 0 ? foWidthSVG / foRect.width : 1;
 
-  // Measure actual content dimensions
-  const realScrollHeight = measureSpanContentHeight(content);
   const contentHeightSVG =
-    realScrollHeight > 0
-      ? realScrollHeight * svgUnitsPerClientPxY
+    contentHeight > 0
+      ? contentHeight * svgUnitsPerClientPxY
       : foHeightSVG;
 
-  const computedStyle = window.getComputedStyle(content);
+  const computedStyle = window.getComputedStyle(fo.firstElementChild as Element);
   const alignItems = computedStyle.alignItems;
   const justifyContent = computedStyle.justifyContent;
-  const contentWidthSVG = shouldKeepForeignObjectWidth(computedStyle)
+  const contentWidthSVG = keepForeignObjectWidth
     ? foWidthSVG
-    : Math.max(foWidthSVG, measureSpanContentWidth(content) * svgUnitsPerClientPxX);
+    : Math.max(foWidthSVG, contentWidth * svgUnitsPerClientPxX);
 
   // Calculate vertical bounds
   let top: number, bottom: number;
@@ -214,6 +227,12 @@ function collectForeignObjectExportAdjustments(svg: SVGSVGElement) {
   ).map((fo) => {
     const content = fo.firstElementChild as HTMLElement | null;
     if (!content) return null;
+    const computedStyle = window.getComputedStyle(content);
+    const keepForeignObjectWidth = shouldKeepForeignObjectWidth(computedStyle);
+    const measuredContent = measureSpanContentDimensions(
+      content,
+      !keepForeignObjectWidth,
+    );
 
     const parent =
       fo.parentElement instanceof SVGGraphicsElement ? fo.parentElement : svg;
@@ -221,11 +240,19 @@ function collectForeignObjectExportAdjustments(svg: SVGSVGElement) {
     const toLocalCoord = createCoordConverter(svg, fo);
     if (!toParentCoord) return null;
 
-    const parentBounds = getFOContentBoundsInSVG(fo, content, toParentCoord);
+    const parentBounds = getFOContentBoundsInSVG(fo, toParentCoord, {
+      contentHeight: measuredContent.height,
+      contentWidth: measuredContent.width,
+      keepForeignObjectWidth,
+    });
     const originalX = parseCoordinate(fo.getAttribute('x'));
     const originalY = parseCoordinate(fo.getAttribute('y'));
     const localBounds = toLocalCoord
-      ? getFOContentBoundsInSVG(fo, content, toLocalCoord)
+      ? getFOContentBoundsInSVG(fo, toLocalCoord, {
+          contentHeight: measuredContent.height,
+          contentWidth: measuredContent.width,
+          keepForeignObjectWidth,
+        })
       : null;
     const hasTransform = fo.hasAttribute('transform');
     if (hasTransform && !localBounds) return null;
@@ -245,7 +272,11 @@ function collectForeignObjectExportAdjustments(svg: SVGSVGElement) {
         };
 
     return {
-      rootBounds: getFOContentBoundsInSVG(fo, content, toSVGCoord),
+      rootBounds: getFOContentBoundsInSVG(fo, toSVGCoord, {
+        contentHeight: measuredContent.height,
+        contentWidth: measuredContent.width,
+        keepForeignObjectWidth,
+      }),
       exportBounds,
     } satisfies ForeignObjectExportAdjustment;
   });


### PR DESCRIPTION
fix: #243 
## 背景

此前 https://github.com/antvis/Infographic/pull/227 commit 为了解决 `foreignObject` 文本在 PNG/SVG 导出时被裁切的问题，引入了导出阶段的包围盒扩展逻辑。

但在 `sequence-timeline-simple` 这类包含多行中文描述文本的场景下，问题并没有真正解决，同时还引入了新的宽度回归：

1. 导出的 PNG 中，部分多行文本最后一行仍然会被截断
2. 导出的 PNG 宽度会被异常撑大

## 根因分析

问题的根因不只是“外层 SVG 导出区域不够大”，而是导出时 `foreignObject` 的尺寸没有和真实换行后的 HTML 文本尺寸保持一致。

具体表现为：

### 1. 布局阶段的文本高度是固定估算值

部分 item 文本（例如 `simple` item 的描述文本）在布局阶段默认按固定行数计算高度，例如默认按 2 行高生成 `foreignObject`。

这意味着：

- 设计阶段的 `foreignObject` 高度是估算值
- 浏览器真实渲染时，长中文文本可能换成更多行
- 真实文本会溢出 `foreignObject` 原始高度

### 2. 之前的修复只处理了“外层 viewBox”，没有彻底修正“内层 foreignObject”

此前的修复尝试通过测量 `foreignObject` 内容溢出来扩展导出时的 `viewBox`，但没有保证导出的克隆 SVG 中，对应 `foreignObject` 自身的 `x/y/width/height` 也同步变为真实内容尺寸。

结果是：

- 外层导出区域有时变大了
- 但内层 `foreignObject` 仍然保留旧的高度
- PNG 渲染时，文本仍会在 `foreignObject` 边界内被裁切

### 3. 宽度测量策略错误，导致 wrapped 文本被按单行宽度处理

此前逻辑会将文本临时切换为 `max-content` 后读取 `scrollWidth`，对于本应按容器宽度自动换行的文本，这等价于测量“单行完全展开宽度”。

该宽度随后被用于扩展导出边界，直接导致 PNG 横向异常变宽。

### 4. 仅使用 `scrollHeight` 测量高度仍然不够准确

在多行中文文本场景下，`scrollHeight` 可能仍小于真实渲染后的文本高度，尤其是最后一行字形底部会出现额外的真实像素高度。

这也是为什么在前一轮修复后，文本虽然行数看起来正确，但最后一行底部仍可能被裁掉。

## 修复内容

本次修复从根因出发，统一修正导出阶段对 `foreignObject` 文本边界的处理：

### 1. wrapped 文本不再按单行宽度扩展

对于启用了换行语义的文本：

- 保留原始 `foreignObject` 宽度
- 不再使用 `max-content` 单行宽度扩展导出边界

这样修复了 PNG 被异常撑宽的问题。

### 2. 将真实文本边界同步回写到导出克隆的 `foreignObject`

导出时，不再只扩展外层 `viewBox`，而是同时将测得的真实文本边界同步写回克隆 SVG 中对应 `foreignObject` 的：

- `x`
- `y`
- `width`
- `height`

这样可以确保 PNG 渲染时，真正承载文本的 `foreignObject` 本身也拥有正确尺寸，不再继续裁切文本。

### 3. 高度测量改为同时参考 `scrollHeight` 和真实渲染高度

文本高度测量改为：

- `Math.max(scrollHeight, getBoundingClientRect().height)`

而不是只信任 `scrollHeight`。

这样可以覆盖多行中文文本最后一行底部 descender 被裁掉的情况。

## 修复效果

以 `sequence-timeline-simple` 的多行中文描述文本为例：
修复前：
<img width="774" height="648" alt="image" src="https://github.com/user-attachments/assets/90ee9c8a-dc14-4a76-b3c0-be2fb0024a30" />
修复后：
<img width="549" height="662" alt="Alibaba Technical Levels P5 to P10 (14)" src="https://github.com/user-attachments/assets/7acfc9f5-0532-4db8-8aff-2151433a14ea" />
