### PR TITLE
fix: support letter and word spacing in text

### DIFF
--- a/__tests__/unit/utils/measure-text.ssr.test.ts
+++ b/__tests__/unit/utils/measure-text.ssr.test.ts
@@ -1,0 +1,57 @@
+import { measureText as measure } from 'measury';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { measureText } from '../../../src/utils/measure-text';
+
+describe('measureText SSR spacing', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('applies letter and word spacing exactly once with measury', () => {
+    vi.stubGlobal('window', undefined);
+    vi.stubGlobal('document', undefined);
+
+    const style = {
+      fontFamily: 'Arial',
+      fontSize: 20,
+      fontWeight: 'normal' as const,
+      lineHeight: 1.4,
+      letterSpacing: 2,
+      wordSpacing: 3,
+    };
+    const actual = measureText('A B', style);
+    const expected = measure('A B', style);
+
+    expect(actual).toEqual({
+      width: Math.ceil(expected.width * 1.015),
+      height: Math.ceil(expected.height * 1.015),
+    });
+  });
+
+  it('normalizes em spacing before passing it to measury', () => {
+    vi.stubGlobal('window', undefined);
+    vi.stubGlobal('document', undefined);
+
+    const actual = measureText('A B', {
+      fontFamily: 'Arial',
+      fontSize: 20,
+      fontWeight: 'normal',
+      lineHeight: 1.4,
+      letterSpacing: '0.1em',
+      wordSpacing: '0.5em',
+    });
+    const expected = measure('A B', {
+      fontFamily: 'Arial',
+      fontSize: 20,
+      fontWeight: 'normal',
+      lineHeight: 1.4,
+      letterSpacing: 2,
+      wordSpacing: 10,
+    });
+
+    expect(actual).toEqual({
+      width: Math.ceil(expected.width * 1.015),
+      height: Math.ceil(expected.height * 1.015),
+    });
+  });
+});

--- a/__tests__/unit/utils/measure-text.test.ts
+++ b/__tests__/unit/utils/measure-text.test.ts
@@ -88,6 +88,40 @@ describe('measureText', () => {
     expect(spanLayoutSpy).not.toHaveBeenCalled();
   });
 
+  it('includes letter and word spacing in canvas measurements', async () => {
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue({
+      font: '',
+      measureText: () => ({ width: 100 }),
+    } as unknown as CanvasRenderingContext2D);
+
+    const { measureText } = await import('../../../src/utils/measure-text');
+    const metrics = measureText('A B', {
+      fontFamily: 'Arial',
+      fontSize: 20,
+      fontWeight: 'normal',
+      letterSpacing: 2,
+      wordSpacing: 3,
+    });
+
+    expect(metrics.width).toBe(Math.ceil(107 * 1.015));
+  });
+
+  it('includes spacing in the server-side fallback measurement', async () => {
+    vi.stubGlobal('window', undefined);
+    vi.stubGlobal('document', undefined);
+
+    const { measureText } = await import('../../../src/utils/measure-text');
+    const metrics = measureText('A B', {
+      fontFamily: 'Arial',
+      fontSize: 20,
+      fontWeight: 'normal',
+      letterSpacing: 2,
+      wordSpacing: 3,
+    });
+
+    expect(metrics.width).toBe(Math.ceil(16 * 1.015));
+  });
+
   it('falls back to measury when canvas is unavailable and span layout is invalid', async () => {
     vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue(null);
     vi.spyOn(

--- a/__tests__/unit/utils/measure-text.test.ts
+++ b/__tests__/unit/utils/measure-text.test.ts
@@ -106,22 +106,6 @@ describe('measureText', () => {
     expect(metrics.width).toBe(Math.ceil(107 * 1.015));
   });
 
-  it('includes spacing in the server-side fallback measurement', async () => {
-    vi.stubGlobal('window', undefined);
-    vi.stubGlobal('document', undefined);
-
-    const { measureText } = await import('../../../src/utils/measure-text');
-    const metrics = measureText('A B', {
-      fontFamily: 'Arial',
-      fontSize: 20,
-      fontWeight: 'normal',
-      letterSpacing: 2,
-      wordSpacing: 3,
-    });
-
-    expect(metrics.width).toBe(Math.ceil(16 * 1.015));
-  });
-
   it('falls back to measury when canvas is unavailable and span layout is invalid', async () => {
     vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue(null);
     vi.spyOn(

--- a/__tests__/unit/utils/text.test.ts
+++ b/__tests__/unit/utils/text.test.ts
@@ -47,6 +47,7 @@ describe('text', () => {
         'font-family': 'Arial',
         'line-height': 1.2,
         'letter-spacing': 1,
+        'word-spacing': 2,
       });
 
       const span = textElement.querySelector('span') as HTMLSpanElement;
@@ -55,6 +56,7 @@ describe('text', () => {
       expect(span.style.fontFamily).toBe('Arial');
       expect(span.style.lineHeight).toBe('1.2');
       expect(span.style.letterSpacing).toBe('1px');
+      expect(span.style.wordSpacing).toBe('2px');
     });
 
     it('should handle horizontal alignment', () => {

--- a/src/renderer/composites/text.ts
+++ b/src/renderer/composites/text.ts
@@ -50,8 +50,7 @@ export function renderItemText(
   const datum = getDatumByIndexes(data, indexes) as ItemDatum | undefined;
   const text = String(get(datum, type, ''));
   const dataAttrs = datum?.attributes?.[type] as
-    | Record<string, any>
-    | undefined;
+    Record<string, any> | undefined;
   const attrs = Object.assign(
     {},
     themeConfig.base?.text,
@@ -109,6 +108,7 @@ function getTextAttributes(textElement: SVGTextElement) {
     'font-style',
     'font-variant',
     'letter-spacing',
+    'word-spacing',
     'line-height',
     'fill',
     'stroke',

--- a/src/types/attrs.ts
+++ b/src/types/attrs.ts
@@ -37,6 +37,7 @@ export type TextAttributes = {
   'font-style'?: NumericalValue;
   'font-variant'?: NumericalValue;
   'letter-spacing'?: NumericalValue;
+  'word-spacing'?: NumericalValue;
   'line-height'?: NumericalValue;
   fill?: TextualValue;
   stroke?: TextualValue;

--- a/src/utils/measure-text.ts
+++ b/src/utils/measure-text.ts
@@ -99,9 +99,11 @@ function resolveSpacing(
 
   const value = spacing.trim();
   if (!value) return 0;
-  const amount = Number.parseFloat(value);
+  const match = value.match(/^([-+]?(?:\d+\.?\d*|\.\d+))(px|em)?$/i);
+  if (!match) return 0;
+  const amount = Number(match[1]);
   if (!Number.isFinite(amount)) return 0;
-  return value.endsWith('em') ? amount * fontSize : amount;
+  return match[2]?.toLowerCase() === 'em' ? amount * fontSize : amount;
 }
 
 function lineSpacing(
@@ -128,17 +130,14 @@ function measureTextInBrowser(
     fontSize: number;
     fontWeight: string | number;
     lineHeight: number | string | undefined;
-    letterSpacing: number | string | undefined;
-    wordSpacing: number | string | undefined;
+    letterSpacing: number;
+    wordSpacing: number;
   },
 ) {
   const lines = content.split(/\r?\n/);
   const normalizedFamily = encodeFontFamily(fontFamily);
   const normalizedWeight = fontWeight || 'normal';
   const lineHeightPx = resolveLineHeight(fontSize, lineHeight);
-  const letterSpacingPx = resolveSpacing(letterSpacing, fontSize);
-  const wordSpacingPx = resolveSpacing(wordSpacing, fontSize);
-
   const context = getCanvasContext();
   if (context) {
     context.font = `${normalizedWeight} ${fontSize}px ${normalizedFamily}`;
@@ -146,7 +145,7 @@ function measureTextInBrowser(
       const metrics = context.measureText(line);
       return Math.max(
         maxWidth,
-        metrics.width + lineSpacing(line, letterSpacingPx, wordSpacingPx),
+        metrics.width + lineSpacing(line, letterSpacing, wordSpacing),
       );
     }, 0);
     return { width, height: lineHeightPx * Math.max(lines.length, 1) };
@@ -158,8 +157,8 @@ function measureTextInBrowser(
   span.style.fontSize = `${fontSize}px`;
   span.style.fontWeight = String(normalizedWeight);
   span.style.lineHeight = `${lineHeightPx}px`;
-  span.style.letterSpacing = `${letterSpacingPx}px`;
-  span.style.wordSpacing = `${wordSpacingPx}px`;
+  span.style.letterSpacing = `${letterSpacing}px`;
+  span.style.wordSpacing = `${wordSpacing}px`;
   span.textContent = content;
   const rect = span.getBoundingClientRect();
   if (content && rect.width <= 0 && rect.height <= 0) return null;
@@ -187,35 +186,20 @@ export function measureText(
 
   const content = text.toString();
   ensureMeasuryFont(fontFamily);
+  const normalizedFontSize = parseFloat(fontSize.toString());
   const options = {
     fontFamily,
-    fontSize: parseFloat(fontSize.toString()),
+    fontSize: normalizedFontSize,
     fontWeight,
     lineHeight,
-    letterSpacing,
-    wordSpacing,
+    letterSpacing: resolveSpacing(letterSpacing, normalizedFontSize),
+    wordSpacing: resolveSpacing(wordSpacing, normalizedFontSize),
   };
-  const fallback = () => {
-    const metrics = measure(content, {
+  const fallback = () =>
+    measure(content, {
       ...options,
       fontFamily: decodeFontFamily(fontFamily),
     });
-    const spacingWidth = content
-      .split(/\r?\n/)
-      .reduce(
-        (maxWidth, line) =>
-          Math.max(
-            maxWidth,
-            lineSpacing(
-              line,
-              resolveSpacing(letterSpacing, options.fontSize),
-              resolveSpacing(wordSpacing, options.fontSize),
-            ),
-          ),
-        0,
-      );
-    return { ...metrics, width: metrics.width + spacingWidth };
-  };
   const metrics = measureTextInBrowser(content, options) ?? fallback();
 
   // 额外添加 1% 宽高

--- a/src/utils/measure-text.ts
+++ b/src/utils/measure-text.ts
@@ -89,6 +89,31 @@ function resolveLineHeight(
   return lineHeight > 4 ? lineHeight : lineHeight * fontSize;
 }
 
+function resolveSpacing(
+  spacing: number | string | undefined,
+  fontSize: number,
+): number {
+  if (spacing === undefined || spacing === null) return 0;
+  if (typeof spacing === 'number')
+    return Number.isFinite(spacing) ? spacing : 0;
+
+  const value = spacing.trim();
+  if (!value) return 0;
+  const amount = Number.parseFloat(value);
+  if (!Number.isFinite(amount)) return 0;
+  return value.endsWith('em') ? amount * fontSize : amount;
+}
+
+function lineSpacing(
+  line: string,
+  letterSpacing: number,
+  wordSpacing: number,
+): number {
+  const letterCount = Math.max(line.length - 1, 0);
+  const wordCount = (line.match(/[ \t]/g) || []).length;
+  return letterCount * letterSpacing + wordCount * wordSpacing;
+}
+
 function measureTextInBrowser(
   content: string,
   {
@@ -96,24 +121,33 @@ function measureTextInBrowser(
     fontSize,
     fontWeight,
     lineHeight,
+    letterSpacing,
+    wordSpacing,
   }: {
     fontFamily: string;
     fontSize: number;
     fontWeight: string | number;
     lineHeight: number | string | undefined;
+    letterSpacing: number | string | undefined;
+    wordSpacing: number | string | undefined;
   },
 ) {
   const lines = content.split(/\r?\n/);
   const normalizedFamily = encodeFontFamily(fontFamily);
   const normalizedWeight = fontWeight || 'normal';
   const lineHeightPx = resolveLineHeight(fontSize, lineHeight);
+  const letterSpacingPx = resolveSpacing(letterSpacing, fontSize);
+  const wordSpacingPx = resolveSpacing(wordSpacing, fontSize);
 
   const context = getCanvasContext();
   if (context) {
     context.font = `${normalizedWeight} ${fontSize}px ${normalizedFamily}`;
     const width = lines.reduce((maxWidth, line) => {
       const metrics = context.measureText(line);
-      return Math.max(maxWidth, metrics.width);
+      return Math.max(
+        maxWidth,
+        metrics.width + lineSpacing(line, letterSpacingPx, wordSpacingPx),
+      );
     }, 0);
     return { width, height: lineHeightPx * Math.max(lines.length, 1) };
   }
@@ -124,6 +158,8 @@ function measureTextInBrowser(
   span.style.fontSize = `${fontSize}px`;
   span.style.fontWeight = String(normalizedWeight);
   span.style.lineHeight = `${lineHeightPx}px`;
+  span.style.letterSpacing = `${letterSpacingPx}px`;
+  span.style.wordSpacing = `${wordSpacingPx}px`;
   span.textContent = content;
   const rect = span.getBoundingClientRect();
   if (content && rect.width <= 0 && rect.height <= 0) return null;
@@ -145,6 +181,8 @@ export function measureText(
     fontSize = 14,
     fontWeight = 'normal',
     lineHeight = 1.4,
+    letterSpacing,
+    wordSpacing,
   } = attrs;
 
   const content = text.toString();
@@ -154,12 +192,30 @@ export function measureText(
     fontSize: parseFloat(fontSize.toString()),
     fontWeight,
     lineHeight,
+    letterSpacing,
+    wordSpacing,
   };
-  const fallback = () =>
-    measure(content, {
+  const fallback = () => {
+    const metrics = measure(content, {
       ...options,
       fontFamily: decodeFontFamily(fontFamily),
     });
+    const spacingWidth = content
+      .split(/\r?\n/)
+      .reduce(
+        (maxWidth, line) =>
+          Math.max(
+            maxWidth,
+            lineSpacing(
+              line,
+              resolveSpacing(letterSpacing, options.fontSize),
+              resolveSpacing(wordSpacing, options.fontSize),
+            ),
+          ),
+        0,
+      );
+    return { ...metrics, width: metrics.width + spacingWidth };
+  };
   const metrics = measureTextInBrowser(content, options) ?? fallback();
 
   // 额外添加 1% 宽高

--- a/src/utils/text.ts
+++ b/src/utils/text.ts
@@ -51,7 +51,14 @@ export function updateTextElement(
     Object.assign(entity.style, getTextStyle(attributes));
     if (!width || !height) {
       const content = textContent ?? getTextContent(text);
-      const { fontFamily, fontSize, fontWeight, lineHeight } = entity.style;
+      const {
+        fontFamily,
+        fontSize,
+        fontWeight,
+        lineHeight,
+        letterSpacing,
+        wordSpacing,
+      } = entity.style;
       const fSize = fontSize ? parseFloat(String(fontSize)) : 12;
       const rect = measureText(content, {
         fontFamily,
@@ -60,6 +67,8 @@ export function updateTextElement(
         lineHeight: lineHeight.endsWith('px')
           ? parseFloat(lineHeight)
           : (parseFloat(lineHeight) || 1.4) * fSize,
+        letterSpacing,
+        wordSpacing,
       });
 
       if (!width && !text.hasAttribute('width')) width = String(rect.width);
@@ -138,6 +147,7 @@ export function getTextStyle(attributes: TextAttributes) {
     ['data-vertical-align']: verticalAlign, // omit
     ['font-size']: fontSize,
     ['letter-spacing']: letterSpacing,
+    ['word-spacing']: wordSpacing,
     ['line-height']: lineHeight,
     fill,
     ['stroke-width']: strokeWidth,
@@ -164,11 +174,19 @@ export function getTextStyle(attributes: TextAttributes) {
       typeof lineHeight === 'string' && lineHeight.endsWith('px')
         ? lineHeight
         : +lineHeight;
-  if (letterSpacing) style.letterSpacing = `${letterSpacing}px`;
+  if (letterSpacing !== undefined)
+    style.letterSpacing = formatSpacing(letterSpacing);
+  if (wordSpacing !== undefined) style.wordSpacing = formatSpacing(wordSpacing);
   if (strokeWidth) style.strokeWidth = `${strokeWidth}px`;
   if (fontFamily) style.fontFamily = encodeFontFamily(fontFamily);
 
   return style;
+}
+
+function formatSpacing(value: number | string): string {
+  if (typeof value === 'number') return `${value}px`;
+  const trimmed = value.trim();
+  return /^[-+]?\d*\.?\d+$/.test(trimmed) ? `${trimmed}px` : trimmed;
 }
 
 export function getTextContent(text: TextElement): string {
@@ -199,6 +217,8 @@ export function getTextElementProps(text: TextElement): Partial<TextProps> {
     justifyContent,
     alignContent,
     fontWeight,
+    letterSpacing,
+    wordSpacing,
   } = entity.style;
 
   const [horizontal, vertical] = flexToAlign(justifyContent, alignContent);
@@ -212,6 +232,8 @@ export function getTextElementProps(text: TextElement): Partial<TextProps> {
   if (fontWeight) attrs['font-weight'] = fontWeight;
   if (fontSize) attrs['font-size'] = String(parseInt(fontSize));
   if (color) attrs['fill'] = color;
+  if (letterSpacing) attrs['letter-spacing'] = letterSpacing;
+  if (wordSpacing) attrs['word-spacing'] = wordSpacing;
 
   return { attributes: attrs, textContent: getTextContent(text) };
 }


### PR DESCRIPTION
## Summary

Fixes #184.

- Include `letterSpacing` and `wordSpacing` in browser and SSR text measurements. Spacing is converted to numbers once (`resolveSpacing`, px and em) and shared by the canvas, span, and SSR paths.
- The SSR fallback passes those numbers to measury, which applies them itself, and adds nothing afterwards. Only the canvas path adds spacing, because canvas `measureText` ignores it.
- Preserve `word-spacing` through the text renderer and apply both spacing values as CSS lengths. `null` spacing values are skipped, as on `main`.
- Add regression coverage: an unmocked SSR test against the real measury, spacing normalization, measured text boxes, and null spacing.

This keeps the change focused on the core `Text` pipeline; business-component-specific style props and optional measurement caching are intentionally outside this PR.

## Validation

Run at ae10e84 in a Linux Codespace with Node 20.20.2 after `npm install`:

- `npx tsc --noEmit -p tsconfig.json`: exit 0
- `npx vitest --run __tests__/unit/utils/measure-text.ssr.test.ts __tests__/unit/utils/measure-text.test.ts __tests__/unit/utils/text.test.ts`: 30 passed
- `npm test`: 91 test files, 771 tests passed
- `npm run build`: exit 0
- `npm run lint:root`: exit 0
- Re-adding the removed SSR spacing addition makes both SSR tests fail; restoring the file makes them pass.
- The null-spacing test fails on 680885e with `TypeError: Cannot read properties of null (reading 'trim')` and passes at ae10e84.

Not run: `site` install, `build:site`, and `lint:site`; this PR does not touch `site/`.
